### PR TITLE
add kong to the terraform template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -149,13 +149,13 @@ resource "google_cloudfunctions_function" "function_convert_xml_to_json" {
 
 # cloud run service
 resource "google_cloud_run_service" "cloudrunsrv" {
-  name     = "api"
+  name     = "kongapi"
   location = local.region
 
   template {
     spec {
       containers {
-        image = "gcr.io/endpoints-release/endpoints-runtime-serverless:2"
+        image = "gcr.io/project-test-270001/kong_dbless:0.3"
       }
     }
   }


### PR DESCRIPTION
# Description
Now that we've moved from cloud endpoints to kong we should add the config to the terraform template.