### PR TITLE
change the format in the terraform apply

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,7 +25,10 @@ steps:
 # Create the resources using Terraform
 - name: hashicorp/terraform
   id: terraform-apply
-  args: ['apply', '-auto-approve', '-var "image_id=gcr.io/$PROJECT_ID/kong_dbless:$SHORT_SHA"'] 
+  entrypoint: 'sh'
+  args: 
+  - '-c'
+  - terraform apply -auto-approve -var image_id=gcr.io/$PROJECT_ID/kong_dbless:$SHORT_SHA 
 
 # Copy the new results back into the bucket.
 - name: gcr.io/cloud-builders/gsutil


### PR DESCRIPTION
# Description
I change the format of the terraform apply because cloud build failed on the argument "apply -auto-approve -var "image_id=gcr.io/project-test-270001/kong_dbless:6970245"